### PR TITLE
Remove redundant .astro/types.d.ts reference from env.d.ts

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,4 +1,3 @@
-/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
 
 declare module "@fontsource/barlow";


### PR DESCRIPTION
## Summary
- Removes the `/// <reference path="../.astro/types.d.ts" />` triple-slash reference that was causing a TypeScript linter error locally
- The reference was redundant — `.astro/types.d.ts` just re-exports `astro/client`, which is already referenced on the next line
- Keeps the `declare module "@fontsource/barlow"` declaration

## Test plan
- [x] `pnpm build` passes with 0 errors, 0 warnings
- [x] Draft deploy to Netlify succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)